### PR TITLE
Fix v1.15.0 download URL

### DIFF
--- a/reports.xml
+++ b/reports.xml
@@ -58,7 +58,7 @@
       <version>
           <num>1.15.0</num>
           <compatibility>10.0.0</compatibility>
-          <download_url>https://github.com/yllen/reports/releases/download/v1.15.0/glpi-reports-1.15.0.tar.gz</download_url>
+          <download_url>https://github.com/yllen/reports/releases/download/V1.15.0/glpi-reports-1.15.0.tar.gz</download_url>
       </version>
       <version>
           <num>1.14.1</num>


### PR DESCRIPTION
The [V1.15.0](https://github.com/yllen/reports/tree/V1.15.0) version has a capital V in its name. The link in the download URL is not correct.